### PR TITLE
fix: alerts only on prod & various fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.libsonnet]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space

--- a/defaults/overrides.libsonnet
+++ b/defaults/overrides.libsonnet
@@ -23,7 +23,7 @@ local defaults        = import '../defaults/values.libsonnet';
       color = defaults.colors.memory_alt
     )),
 
-  cpu_memory(cfg, refid_cpu = defaults.refid.cpu, refid_mem = defaults.refid.mem):: cfg
+  cpu_memory(cfg, refid = defaults.refid.cpu, refid_mem = defaults.refid.mem):: cfg
     .addOverride(grafana.override.newColorOverride(
       name = '%s_Avg' % refid,
       color = defaults.colors.cpu

--- a/defaults/panels/aws/amqp/cpu.libsonnet
+++ b/defaults/panels/aws/amqp/cpu.libsonnet
@@ -26,15 +26,18 @@ local refid_CPU_Avg   = '%s_Avg' % defaults.values.refid.cpu;
     defaults.configuration.timeseries_resource
   )
 
-  .setAlert(defaults.alerts.cpu(
-    namespace     = namespace,
-    env           = environment,
-    title         = title,
-    notifications = notifications,
-    priority      = priority,
-    limit         = limit,
-    reducer       = reducer,
-  ))
+  .setAlert(
+    environment,
+    defaults.alerts.cpu(
+      namespace     = namespace,
+      env           = environment,
+      title         = title,
+      notifications = notifications,
+      priority      = priority,
+      limit         = limit,
+      reducer       = reducer,
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias       = "CPU (Max)",

--- a/defaults/panels/aws/docdb/available_memory.libsonnet
+++ b/defaults/panels/aws/docdb/available_memory.libsonnet
@@ -30,7 +30,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
         { value: mem_threshold, color: defaults.values.colors.ok },
       ]
     )
-    .withUnit(grafana.fieldConfig.units.Kibibytes)
+    .withUnit(grafana.fieldConfig.units.DecBytes)
     .addOverride(grafana.override.newColorOverride(refid_Mem_Min, defaults.values.colors.memory_alt))
     .addOverride(grafana.override.newColorOverride(refid_Mem_Avg, defaults.values.colors.memory))
     .withSoftLimit(

--- a/defaults/panels/aws/docdb/available_memory.libsonnet
+++ b/defaults/panels/aws/docdb/available_memory.libsonnet
@@ -44,6 +44,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
   )
 
   .setAlert(
+    environment,
     grafana.alert.new(
       namespace     = namespace,
       name          = '%s - DocumentDB - Available Memory alert'              % environment,

--- a/defaults/panels/aws/docdb/cpu.libsonnet
+++ b/defaults/panels/aws/docdb/cpu.libsonnet
@@ -34,28 +34,31 @@ local colors = {
     .addOverride(grafana.override.newColorOverride(refids.cpu_reader_max, colors.cpu_reader_max))
     .addOverride(grafana.override.newColorOverride(refids.cpu_reader_avg, colors.cpu_reader_avg))
   )
-  .setAlert(grafana.alert.new(
-    namespace     = namespace,
-    name          = "%s - DocumentDB - CPU alert" % environment,
-    message       = "%s - DocumentDB - CPU alert" % environment,
-    notifications = notifications,
-    conditions  = [
-      grafana.alertCondition.new(
-        evaluatorParams = [ defaults.values.resource.thresholds.critical ],
-        evaluatorType   = grafana.alertCondition.evaluators.Above,
-        operatorType    = grafana.alertCondition.operators.Or,
-        queryRefId      = refids.cpu_writer_max,
-        reducerType     = grafana.alertCondition.reducers.Avg,
-      ),
-      grafana.alertCondition.new(
-        evaluatorParams = [ defaults.values.resource.thresholds.critical ],
-        evaluatorType   = grafana.alertCondition.evaluators.Above,
-        operatorType    = grafana.alertCondition.operators.Or,
-        queryRefId      = refids.cpu_reader_max,
-        reducerType     = grafana.alertCondition.reducers.Avg,
-      ),
-    ]
-  ))
+  .setAlert(
+    environment,
+    grafana.alert.new(
+      namespace     = namespace,
+      name          = "%s - DocumentDB - CPU alert" % environment,
+      message       = "%s - DocumentDB - CPU alert" % environment,
+      notifications = notifications,
+      conditions  = [
+        grafana.alertCondition.new(
+            evaluatorParams = [ defaults.values.resource.thresholds.critical ],
+            evaluatorType   = grafana.alertCondition.evaluators.Above,
+            operatorType    = grafana.alertCondition.operators.Or,
+            queryRefId      = refids.cpu_writer_max,
+            reducerType     = grafana.alertCondition.reducers.Avg,
+        ),
+        grafana.alertCondition.new(
+            evaluatorParams = [ defaults.values.resource.thresholds.critical ],
+            evaluatorType   = grafana.alertCondition.evaluators.Above,
+            operatorType    = grafana.alertCondition.operators.Or,
+            queryRefId      = refids.cpu_reader_max,
+            reducerType     = grafana.alertCondition.reducers.Avg,
+        ),
+      ]
+    )
+  )
   .addTarget(grafana.targets.cloudwatch(
     alias       = 'CPU Writer (Max)',
     datasource  = datasource,

--- a/defaults/panels/aws/docdb/low_mem_op_throttled.libsonnet
+++ b/defaults/panels/aws/docdb/low_mem_op_throttled.libsonnet
@@ -34,6 +34,7 @@ local refid_Ops_Max   = 'Ops_Max';
   )
 
   .setAlert(
+    environment,
     grafana.alert.new(
       namespace     = namespace,
       name          = "%s - DocumentDB - LowMem Num Operations Throttled Alert" % environment,

--- a/defaults/panels/aws/ecs/cpu.libsonnet
+++ b/defaults/panels/aws/ecs/cpu.libsonnet
@@ -32,19 +32,22 @@ local refid_CPU_Avg   = '%s_Avg' % defaults.values.refid.cpu;
     defaults.configuration.timeseries_resource
   )
 
-  .setAlert(defaults.alerts.cpu(
-    namespace     = namespace,
-    env           = environment,
-    title         = title,
-    notifications = notifications,
-    priority      = priority,
-    timeStart     = timeStart,
-    period        = period,
-    frequency     = frequency,
-    refid         = refid,
-    limit         = limit,
-    reducer       = reducer,
-  ))
+  .setAlert(
+    environment,
+    defaults.alerts.cpu(
+      namespace     = namespace,
+      env           = environment,
+      title         = title,
+      notifications = notifications,
+      priority      = priority,
+      timeStart     = timeStart,
+      period        = period,
+      frequency     = frequency,
+      refid         = refid,
+      limit         = limit,
+      reducer       = reducer,
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias         = 'CPU (Max)',

--- a/defaults/panels/aws/ecs/cpu_memory.libsonnet
+++ b/defaults/panels/aws/ecs/cpu_memory.libsonnet
@@ -65,7 +65,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.CPUUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,
@@ -78,7 +78,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.CPUUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,
@@ -92,7 +92,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.MemoryUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,
@@ -105,7 +105,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.MemoryUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,

--- a/defaults/panels/aws/ecs/cpu_memory.libsonnet
+++ b/defaults/panels/aws/ecs/cpu_memory.libsonnet
@@ -37,27 +37,30 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     defaults.configuration.timeseries_resource
   )
 
-  .setAlert(defaults.alerts.cpu_mem(
-    namespace     = namespace,
-    env           = environment,
-    title         = title,
-    notifications = notifications,
-    priority      = priority,
-    period        = period,
-    frequency     = frequency,
-    cpu           = {
-      refid       : cpu_refid,
-      limit       : cpu_limit,
-      reducer     : cpu_reducer,
-      timeStart   : timeStart,
-    },
-    memory        = {
-      refid       : memory_refid,
-      limit       : memory_limit,
-      reducer     : memory_reducer,
-      timeStart   : timeStart,
-    },
-  ))
+  .setAlert(
+    environment,
+    defaults.alerts.cpu_mem(
+      namespace     = namespace,
+      env           = environment,
+      title         = title,
+      notifications = notifications,
+      priority      = priority,
+      period        = period,
+      frequency     = frequency,
+      cpu           = {
+        refid       : cpu_refid,
+        limit       : cpu_limit,
+        reducer     : cpu_reducer,
+        timeStart   : timeStart,
+      },
+      memory        = {
+        refid       : memory_refid,
+        limit       : memory_limit,
+        reducer     : memory_reducer,
+        timeStart   : timeStart,
+      },
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias         = 'CPU (Max)',

--- a/defaults/panels/aws/ecs/memory.libsonnet
+++ b/defaults/panels/aws/ecs/memory.libsonnet
@@ -32,19 +32,22 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     defaults.configuration.timeseries_resource
   )
 
-  .setAlert(defaults.alerts.memory(
-    namespace     = namespace,
-    env           = environment,
-    title         = title,
-    notifications = notifications,
-    priority      = priority,
-    timeStart     = timeStart,
-    period        = period,
-    frequency     = frequency,
-    refid         = refid,
-    limit         = limit,
-    reducer       = reducer,
-  ))
+  .setAlert(
+    environment,
+    defaults.alerts.memory(
+      namespace     = namespace,
+      env           = environment,
+      title         = title,
+      notifications = notifications,
+      priority      = priority,
+      timeStart     = timeStart,
+      period        = period,
+      frequency     = frequency,
+      refid         = refid,
+      limit         = limit,
+      reducer       = reducer,
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias         = 'Memory (Max)',

--- a/defaults/panels/aws/ecs/memory.libsonnet
+++ b/defaults/panels/aws/ecs/memory.libsonnet
@@ -52,7 +52,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.MemoryUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,
@@ -65,7 +65,7 @@ local refid_Mem_Avg   = '%s_Avg' % defaults.values.refid.mem;
     namespace     = grafana.target.cloudwatch.namespace.ECS,
     metricName    = grafana.target.cloudwatch.metrics.ecs.MemoryUtilization,
     dimensions    = {
-      ServiceName: service_name
+      ServiceName: service_name,
       [if cluster_name != null then 'ClusterName']: cluster_name,
     },
     matchExact    = matchExact,

--- a/defaults/panels/aws/redis/cpu.libsonnet
+++ b/defaults/panels/aws/redis/cpu.libsonnet
@@ -21,13 +21,16 @@ local refid_EngineCPU_Max = '%s_Engine_Max' % defaults.values.refid.mem;
 
   .configure(defaults.configuration.timeseries_resource)
 
-  .setAlert(defaults.alerts.cpu(
+  .setAlert(
+    environment,
+    defaults.alerts.cpu(
       namespace     = namespace,
       env           = environment,
       title         = title,
       notifications = notifications,
       priority      = priority,
-  ))
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias       = 'Host CPU',

--- a/defaults/panels/aws/redis/memory.libsonnet
+++ b/defaults/panels/aws/redis/memory.libsonnet
@@ -20,13 +20,16 @@ local refid_Mem_Max   = '%s_Max' % defaults.values.refid.mem;
 
   .configure(defaults.configuration.timeseries_resource)
 
-  .setAlert(defaults.alerts.memory(
+  .setAlert(
+    environment,
+    defaults.alerts.memory(
       namespace     = namespace,
       env           = environment,
       title         = "%s - %s"   % [environment, title],
       notifications = notifications,
       priority      = priority,
-  ))
+    )
+  )
 
   .addTarget(grafana.targets.cloudwatch(
     alias       = 'Memory (Max)',

--- a/defaults/panels/aws/redis/swap_usage.libsonnet
+++ b/defaults/panels/aws/redis/swap_usage.libsonnet
@@ -23,6 +23,7 @@ local refid_Pressure        = 'Pressure';
   .configure(defaults.configuration.timeseries)
 
   .setAlert(
+    environment,
     grafana.alert.new(
       namespace     = namespace,
       name          = "%s - %s - Swap Usage alert"    % [grafana.utils.strings.capitalize(environment), title],

--- a/panels/panel.libsonnet
+++ b/panels/panel.libsonnet
@@ -82,8 +82,8 @@
 
 
       // Alerts
-      setAlert(alert):: self {
+      setAlert(environment, alert):: if environment == "prod" then self {
         alert: alert
-      },
+      } else self,
     },
 }


### PR DESCRIPTION
- Only create alerts on prod env. This saves on the alert quota
- Fix DocDB memory unit. It was showing memory in TiB when it should be GB
- Fix various syntax issues
- Add editorconfig