### PR TITLE
fix: Redis alarms

### DIFF
--- a/defaults/panels/aws/redis/cpu.libsonnet
+++ b/defaults/panels/aws/redis/cpu.libsonnet
@@ -29,6 +29,7 @@ local refid_EngineCPU_Max = '%s_Engine_Max' % defaults.values.refid.mem;
       title         = title,
       notifications = notifications,
       priority      = priority,
+      reducer       = grafana.alertCondition.reducers.Max,
     )
   )
 

--- a/defaults/panels/aws/redis/memory.libsonnet
+++ b/defaults/panels/aws/redis/memory.libsonnet
@@ -28,6 +28,7 @@ local refid_Mem_Max   = '%s_Max' % defaults.values.refid.mem;
       title         = "%s - %s"   % [environment, title],
       notifications = notifications,
       priority      = priority,
+      reducer       = grafana.alertCondition.reducers.Max,
     )
   )
 


### PR DESCRIPTION
Issue: https://github.com/WalletConnect/notify-server/actions/runs/7546764769/job/20545940471#step:9:1924

These metrics use `statistic=Max` so we need to change the default alarm config to also use this reducer.